### PR TITLE
Use proper EUC name

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -7,7 +7,7 @@ featured_image: './header.jpg'
 
 Welcome to the website of the NWERC 2024!
 
-The Northwestern Europe Regional Contest (NWERC) is a contest in which teams from universities all over the Northwestern part of Europe are served a series of algorithmic problems. The goal of each team is to solve as many problems as possible within the 5 hour time limit. Potential solutions are submitted and corrected by an automated judging system. The three teams that solve the most problems at the end of the contest qualify for the [ICPC World Finals](https://icpc.global/). These three teams, and ten more teams among the top, also qualify for the [ICPC European Championship](https://euc.icpc.global/).
+The Northwestern Europe Regional Contest (NWERC) is a contest in which teams from universities all over the Northwestern part of Europe are served a series of algorithmic problems. The goal of each team is to solve as many problems as possible within the 5 hour time limit. Potential solutions are submitted and corrected by an automated judging system. The three teams that solve the most problems at the end of the contest qualify for the [ICPC World Finals](https://icpc.global/). These three teams, and ten more teams among the top, also qualify for the [ICPC Europe Championship](https://euc.icpc.global/).
 
 The 2024 edition of the Northwestern Europe Regional Contest (NWERC) will be held from the 22nd until the 24th of November 2024.
 The contest will be held on the campus of the Delft University of Technology. This year's edition wil be a lit(e) version with only a single team per university.


### PR DESCRIPTION
The official name of the EUC is the ICPC Europe Championship, like the NWERC is the Northwestern Europe Regional Contest.