### PR TITLE
rules.md: Rephrase that teams are not allowed to replace the provided keyboard and mouse

### DIFF
--- a/content/rules.md
+++ b/content/rules.md
@@ -21,8 +21,10 @@ A student may compete when eligible according to the [official ICPC regional rul
 ## Contest Materials
 We follow the World Finals’ Rules, so a team is allowed to bring 3 copies of their Team Reference Document, but not allowed
 to bring any additional reference materials such as books, program listings and notes! You may not bring any electronic device
-or machine-readable media (this includes but is not limited to cell phones, **watches**, digital cameras, and mp3 players). You may bring
-pens or pencils, but not paper (these will be provided). Winter coats, bags, etc. should not be brought to the contest floor.
+or machine-readable media (this includes but is not limited to cell phones, **watches**, digital cameras, and mp3 players).
+Teams are **not** allowed to replace the provided keyboard and mouse.
+You may bring pens or pencils, but not paper (these will be provided).
+Winter coats, bags, etc. should not be brought to the contest floor.
 
 Each contestant may bring a copy of a Team Reference Document. This document may contain up to 25 pages of reference materials,
 single-sided, letter or A4 size, with pages numbered in the upper right-hand corner and your university name printed in the upper
@@ -33,8 +35,6 @@ in some type of notebook or folder with the name of your institution on the fron
 Each team member may bring one printed, unannotated natural language dictionary. You may bring mascots such as stuffed
 toy animals or party hats (provided they do not violate any of the above constraints). If there is some other item your
 team needs at the contest, please contact the Head of Jury.
-
-Teams are **not** allowed to bring one keyboard to replace the provided keyboard and mouse. 
 
 Team Reference Documents should be handed in at the registration.
 Mascots and other items (see above) can be brought to the team's table during the test session.


### PR DESCRIPTION
I would like to link to the systems page to show what kind of keyboard and mouse we provide, but that does not exist yet :slightly_smiling_face: It's also nice to add photos of the keyboard and mouse that we provide, just like the [EUC](https://euc.icpc.global/home-2024/programming-environment/) :smile: