### PR TITLE
content/systems.md: Update to versions used at DAPC 2024

### DIFF
--- a/content/systems.md
+++ b/content/systems.md
@@ -14,7 +14,7 @@ Each team will have access to one workstation, shared between team members.
 
 The software configuration will consist of the following:
 - OS:
-    - Ubuntu 22.04 LTS Linux (64-bit)
+    - Ubuntu 24.04 LTS Linux (64-bit)
 - Desktop:
     - Xfce
 - Editors:
@@ -65,15 +65,15 @@ The software configuration will consist of the following:
 The following languages are allowed during the contest:
 
 - C
-    - Compiler version: 11.3.0
+    - Compiler version: 11.4.0
     - Standard: gnu17
 - C++
-    - Compiler version: 11.3.0
+    - Compiler version: 11.4.0
     - Standard: gnu++20
 - Python
-    - Version: PyPy 7.3.9 (Python 3.8.13)
+    - Version: PyPy 7.3.16 (Python 3.10.14)
 - Java
-    - Version: 17.0.6
+    - Version: 17.0.8
 - Kotlin
     - Version: 1.7.21
 
@@ -81,7 +81,7 @@ Note that Python 2 is no longer supported.
 
 ## Compilation of Submissions
 
-During the contest, teams will submit proposed solutions to the contest problems to the Judges using the [DOMjudge](https://www.domjudge.org) contest control system (version 8.1). This can be done through the [web interface](https://www.domjudge.org/docs/manual/8.1/team.html#web-interface), or using the [submit client](https://www.domjudge.org/docs/manual/8.1/team.html#command-line-submit).
+During the contest, teams will submit proposed solutions to the contest problems to the Judges using the [DOMjudge](https://www.domjudge.org) contest control system (version 8.3.1). This can be done through the [web interface](https://www.domjudge.org/docs/manual/8.3/team.html#web-interface), or using the [submit client](https://www.domjudge.org/docs/manual/8.3/team.html#command-line-submit).
 Source files submitted to the Judges will be compiled using the following command line arguments for the respective language:
 
 - C:
@@ -126,7 +126,7 @@ The following reference materials will be available on the teams' workstations t
 
 - [C reference from cppreference.com](https://en.cppreference.com/w/c)
 - [C++ reference from cppreference.com](https://en.cppreference.com/w/cpp)
-- [Python 3.8.13 documentation](https://docs.python.domainunion.de/release/3.8.13/)
+- [Python 3.10.13 documentation](https://docs.python.domainunion.de/release/3.10.13/)
 - [Java® Platform, Standard Edition & Java Development Kit Version 17 API Specification](https://docs.oracle.com/en/java/javase/17/docs/api/)
 - [Kotlin Language Documentation 1.6.20 (As PDF)](http://web.archive.org/web/20220610202819if_/https://kotlinlang.org/docs/kotlin-reference.pdf)
-- [DOMjudge Team Manual (As PDF)](https://www.domjudge.org/docs/manual/8.1/team.html)
+- [DOMjudge Team Manual (As PDF)](https://www.domjudge.org/docs/manual/8.3/team.html)


### PR DESCRIPTION
This will likely not change much before NWERC, but in any case they won't _decrease_, so this should be safe 🙂
Changes taken from https://github.com/WISVCH/chipcie-website/pull/63.

Note the deliberate difference between "we provide PyPy with Python 3.10.**_14_**" and "we provide documentation of Python 3.10.**_13_**", see https://github.com/WISVCH/icpc-env/commit/e1e1b4420d0943cdf5e4816a8180c6a647238b61#commitcomment-146938879