### PR TITLE
Update event titles and remove schedule change notice

### DIFF
--- a/content/schedule/_index.md
+++ b/content/schedule/_index.md
@@ -6,8 +6,6 @@ draft: false
 menu: main
 weight: 3
 ---
-This schedule is subject to change. Rooms and times might (slightly) change. The final schedule will be posted no later
-than the 18th of November.
 
 ## Friday - November 22, 2024
 {{< timetable day="friday" from="14" to="21" >}}

--- a/content/schedule/registration.md
+++ b/content/schedule/registration.md
@@ -1,5 +1,5 @@
 ---
-title: "Registration (time subject to change)"
+title: "Registration"
 type: event
 day: friday
 start: 14:00

--- a/content/schedule/registration.md
+++ b/content/schedule/registration.md
@@ -19,6 +19,6 @@ The registration is held in the `\` (backslash) in the basement of the Faculty E
 Follow the signs, or use the following directions. 
 When entering the building, walk towards the elevators and take the stairs down on the right hand side.
 At the bottom of the stairs go right through two red sliding doors.
-Walk around the green cage and turn left. 
+Walk around the green cage and turn right. 
 
  

--- a/content/schedule/registration.md
+++ b/content/schedule/registration.md
@@ -5,7 +5,7 @@ day: friday
 start: 14:00
 duration: 7h0m
 width: 1
-location: Faculty EEMCS
+location: Faculty EEMCS - \
 people: all
 ---
 
@@ -14,5 +14,11 @@ During registration all team members and on-site coaches need to register. You w
 ## Location
 The registration takes place in [Faculty EEMCS](https://map.tudelftcampus.nl/poi/elektrotechniek-wiskunde-en-informatica-ewi/).
 This is the tall red/blue building.
-Exact location will be added later.
-For directions, see the [Location page]({{< relref "location" >}} "Location").
+
+The registration is held in the `\` (backslash) in the basement of the Faculty EEMCs.
+Follow the signs, or use the following directions. 
+When entering the building, walk towards the elevators and take the stairs down on the right hand side.
+At the bottom of the stairs go right through two red sliding doors.
+Walk around the green cage and turn left. 
+
+ 

--- a/content/schedule/registration.md
+++ b/content/schedule/registration.md
@@ -15,7 +15,7 @@ During registration all team members and on-site coaches need to register. You w
 The registration takes place in [Faculty EEMCS](https://map.tudelftcampus.nl/poi/elektrotechniek-wiskunde-en-informatica-ewi/).
 This is the tall red/blue building.
 
-The registration is held in the Back/ (Backslash) in the basement of the Faculty EEMCs.
+The registration is held in the Back/ (Backslash) in the basement of the Faculty EEMCS.
 Follow the signs, or use the following directions. 
 When entering the building, walk towards the elevators and take the stairs down on the right hand side.
 At the bottom of the stairs go right through two red sliding doors.

--- a/content/schedule/registration.md
+++ b/content/schedule/registration.md
@@ -5,7 +5,7 @@ day: friday
 start: 14:00
 duration: 7h0m
 width: 1
-location: Faculty EEMCS - \
+location: Faculty EEMCS - Back/
 people: all
 ---
 
@@ -15,7 +15,7 @@ During registration all team members and on-site coaches need to register. You w
 The registration takes place in [Faculty EEMCS](https://map.tudelftcampus.nl/poi/elektrotechniek-wiskunde-en-informatica-ewi/).
 This is the tall red/blue building.
 
-The registration is held in the `\` (backslash) in the basement of the Faculty EEMCs.
+The registration is held in the Back/ (Backslash) in the basement of the Faculty EEMCs.
 Follow the signs, or use the following directions. 
 When entering the building, walk towards the elevators and take the stairs down on the right hand side.
 At the bottom of the stairs go right through two red sliding doors.

--- a/content/schedule/registration.md
+++ b/content/schedule/registration.md
@@ -19,6 +19,5 @@ The registration is held in the Back/ (Backslash) in the basement of the Faculty
 Follow the signs, or use the following directions. 
 When entering the building, walk towards the elevators and take the stairs down on the right hand side.
 At the bottom of the stairs go right through two red sliding doors.
-Walk around the green cage and turn right. 
-
- 
+Walk forward through the bicycle parking and go right at the second intersection, which is behind the green cage.
+If you see the ramp up, you have gone too far and should have followed the signs.


### PR DESCRIPTION
Simplified the "Registration" event title and removed the notice about schedule changes from the schedule index. This ensures clarity and minimizes potential confusion regarding event times and locations.