### PR TITLE
Add contest materials to home page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -12,3 +12,40 @@ The Northwestern Europe Regional Contest (NWERC) is a contest in which teams fro
 The 2024 edition of the Northwestern Europe Regional Contest (NWERC) will be held from the 22nd until the 24th of November 2024.
 The contest will be held on the campus of the Delft University of Technology. This year's edition will be a lit(e) version.
 
+{{% row %}}
+{{% column %}}
+
+## Contest material
+
+<!--
+- [Photos](https://2024.nwerc.eu/photos)
+- [Final Standings](/main/scoreboard) ([Spectators](/main/scoreboard/spectators.html))
+- [Problem Set (pdf)](/main/problem-set.pdf)
+- [Problem Slides (pdf)](/main/problem-slides.pdf)
+- [Solution Slides (pdf)](/main/solutions.pdf)
+- [Packaged Problems (.zip, ???MB)](https://chipcie.wisv.ch/archive/2023/nwerc/solutions.zip)
+-->
+- [Live Scoreboard](https://scoreboard.nwerc.eu)<!-- TODO: remove after Final Standings are available -->
+- [Spectator Contest](https://spectator.nwerc.eu)<!-- TODO: remove after Final Standings are available -->
+- [Contest Livestream](https://www.youtube.com/watch?v=Ho3z9XpJ5AA)
+- [Award Ceremony Livestream](https://www.youtube.com/watch?v=Z1HO34X9qSA)
+
+{{% /column %}}
+{{% column %}}
+
+## Test session material
+
+<!--
+- [Final Standings](/test-session/scoreboard)
+- [Problem Set (pdf)](/test-session/problem-set.pdf)
+- [Problem Slides (pdf)](/test-session/problem-slides.pdf)
+- [Solution Slides (pdf)](/test-session/solutions.pdf)
+- [Packaged Problems (.zip, ???MB)](/test-session/solutions.zip)
+-->
+- [Live Scoreboard](https://scoreboard.nwerc.eu)<!-- TODO: remove after Final Standings are available -->
+- [Spectator Contest](https://spectator.nwerc.eu)<!-- TODO: remove after Final Standings are available -->
+- [Opening Ceremony Livestream](https://www.youtube.com/watch?v=qkcMuoyBoWg)
+- [Test Session and Team Interviews Livestream](https://www.youtube.com/watch?v=cj5lXaF88hA)
+
+{{% /column %}}
+{{% /row %}}

--- a/content/news/spectator-announcement.md
+++ b/content/news/spectator-announcement.md
@@ -7,6 +7,6 @@ date: 2024-11-21T09:00:00+01:00
 There will be an online spectator contest again this year.
 The main contest will start at 10:30 CET on Sunday (November 24th, 2024).
 This is half an hour later than the start of the real contest.
-The test session on Saturday will also be available for the online spectator contest.
+The test session on Saturday will also be available on the online spectator contest.
 
 You can register at https://spectator.nwerc.eu/ once the website is live, this will probably be on Friday.

--- a/content/news/spectator-announcement.md
+++ b/content/news/spectator-announcement.md
@@ -1,0 +1,11 @@
+---
+title: Online Spectator Contest
+tags: ['nwerc 2024']
+date: 2024-11-21T09:00:00+01:00
+---
+
+There will be an online spectator contest again this year.
+The contest will start at 10:30 CET on Sunday (November 24th, 2024).
+This is half an hour later than the start of the real contest.
+
+You can register at https://spectator.nwerc.eu/ once the website is live, this will probably be on Friday.

--- a/content/news/spectator-announcement.md
+++ b/content/news/spectator-announcement.md
@@ -5,7 +5,8 @@ date: 2024-11-21T09:00:00+01:00
 ---
 
 There will be an online spectator contest again this year.
-The contest will start at 10:30 CET on Sunday (November 24th, 2024).
+The main contest will start at 10:30 CET on Sunday (November 24th, 2024).
 This is half an hour later than the start of the real contest.
+The test session on Saturday will also be available for the online spectator contest.
 
 You can register at https://spectator.nwerc.eu/ once the website is live, this will probably be on Friday.


### PR DESCRIPTION
Just grabbed the live stream URLs from https://www.youtube.com/@ICPCLive :smile:

I've copied all listed contest materials from last year and commented them out.

I've also added the live scoreboard and spectator contest to both.

@maartenweyns @verwoerd Do you know if we'll have a spectator contest for the test session as well? If not, it can be removed from the test session materials :slightly_smiling_face: 