### PR TITLE
Add NWERC 2024 conclusion news article

### DIFF
--- a/content/news/nwerc-conclusion.md
+++ b/content/news/nwerc-conclusion.md
@@ -27,6 +27,6 @@ Additionally, the following teams have qualified for the [Europe Championship 20
 12. **🥶** (Chalmers University of Technology)
 13. **addicted (òvó)** (Saarland University)
 
-We apologize for mistakenly announcing that Test2 had qualified for the EUC. Due to the rule that only one team per institution can advance, the team addicted (òvó) from Saarland University has qualified instead.
+We apologize for mistakenly announcing during the Award Ceremony that team **Test2** (Oxford) had qualified for the EUC. Due to the rule that only one team per institution can advance, the team **addicted (òvó)** from Saarland University has qualified instead.
 
-In the coming weeks, we will make the photos and home directories available. The photos will be linked on this page, and we will notify all participants via email once they are accessible.
+In the coming weeks, we will make the photos and home directories available. The photos will be linked on our website, and we will notify all participants via email once they are accessible.

--- a/content/news/nwerc-conclussion.md
+++ b/content/news/nwerc-conclussion.md
@@ -1,0 +1,32 @@
+---
+title: Conclusion of NWERC
+tags: [ 'nwerc 2024' ]
+date: 2024-11-27T00:14:00+01:00
+---
+The NWERC 2024 has concluded. Congratulations to the champion, **Kindergarten Timelimit**, from Karlsruhe Institute of Technology.
+
+The following teams have qualified for the ICPC World Finals 2025:
+
+1. **Kindergarten Timelimit** (Karlsruhe Institute of Technology)
+2. **Segfault go BRRRR** (Delft University of Technology)
+3. **Seems to be O(k!)** (Hasso Plattner Institute)
+
+Additionally, the following teams have qualified for the [Europe Championship 2025 in Porto](https://euc.icpc.global):
+
+1. **Kindergarten Timelimit** (Karlsruhe Institute of Technology)
+2. **Segfault go BRRRR** (Delft University of Technology)
+3. **Seems to be O(k!)** (Hasso Plattner Institute)
+4. **Pizza Driven Development** (Aarhus University)
+5. **placeholder** (University of Oxford)
+6. **Oecher** (RWTH Aachen University)
+7. **Bubblegum Bitset** (University of Tartu)
+8. **Friday Volleyball** (University of Amsterdam)
+9. **TriTUMvirate** (Technische Universität München)
+10. **Team Biem** (Utrecht University)
+11. **Unity** (University of Cambridge)
+12. **🥶** (Chalmers University of Technology)
+13. **addicted (òvó)** (Saarland University)
+
+We apologize for mistakenly announcing that Test2 had qualified for the EUC. Due to the rule that only one team per institution can advance, the team addicted (òvó) from Saarland University has qualified instead.
+
+In the coming weeks, we will make the photos and home directories available. The photos will be linked on this page, and we will notify all participants via email once they are accessible.


### PR DESCRIPTION
Introduce a new article summarizing the conclusion of NWERC 2024. It includes the list of teams qualified for the ICPC World Finals and the Europe Championship 2025, and an apology for a previous announcement error. Future steps include the release of photos and home directories for participants.